### PR TITLE
Fix TypeScript build errors by commenting out unused code

### DIFF
--- a/src/pages/account-form/AccountForm.tsx
+++ b/src/pages/account-form/AccountForm.tsx
@@ -3,7 +3,7 @@
 import { useState, useCallback, useEffect } from "react"
 import { ArrowLeft, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
+// import { Input } from "@/components/ui/input"
 import { useLocation, useNavigate } from "react-router-dom";
 import { Label } from "@/components/ui/label"
 import { Bounce, ToastContainer, toast } from "react-toastify";
@@ -29,7 +29,7 @@ export default function AccountForm() {
   const [queueNumber, setQueueNumber] = useState("");
   const [transactionType, setTransactionType] = useState("deposit")
   const location = useLocation();
-  const [accountType, setAccountType] = useState("savings")
+  // const [accountType, setAccountType] = useState("savings")
   const [depositType, setDepositType] = useState("cash")
   const { validate, } = useTransaction();
   const { deposit } = depositTransaction();
@@ -43,7 +43,7 @@ export default function AccountForm() {
   const [amount, setAmount] = useState<number>(0);
   const [currentUser, setCurrentUser] = useState<any>({});
   const [userType, setUserType] = useState("")
-  const [depositor, setDepositor] = useState<string>("");
+  const [depositor, /* setDepositor */] = useState<string>("");
 
   const [chequeValidated, setChequeValidated] = useState<boolean>(false);
   const [loadingCheque, setLoadingCheque] = useState<boolean>(false);
@@ -319,10 +319,10 @@ export default function AccountForm() {
       });
   };
 
-  const handleDetailProceed = () => {
-    setShowDetailModal(false)
-    setShowOtpModal(true)
-  }
+  // const handleDetailProceed = () => {
+  //   setShowDetailModal(false)
+  //   setShowOtpModal(true)
+  // }
 
   const handleOtpChange = (index: number, value: string) => {
     if (value.length <= 1) {

--- a/src/services/account/account.service.ts
+++ b/src/services/account/account.service.ts
@@ -1,4 +1,4 @@
-import axios, { type AxiosInstance, type AxiosResponse } from "axios";
+import axios, { type AxiosInstance } from "axios";
 import { generateKey,decodeKey,generateforString } from "../../utils/jwtToken";
 import { safeQuery } from "@/utils/sanitizer";
 
@@ -40,7 +40,7 @@ export class AccountService {
           
         })
         .then(async res => {
-          const retrievedData = await decodeKey(res.data.data)
+          // const retrievedData = await decodeKey(res.data.data)
           return decodeKey(res.data.data)
         })
     }

--- a/src/utils/base.enum.ts
+++ b/src/utils/base.enum.ts
@@ -1,17 +1,15 @@
-export enum DepositType{
-    Cash = "cash",
-    Cheque = "Cheque",
-    
-}
+export const DepositType = {
+    Cash: "cash",
+    Cheque: "Cheque",
+} as const;
 
-export enum AccountType{
-    Savings = "saving",
-    Current = "current",
-    
-}
 
-export enum CustomerType{
-    Self = "self",
-    ThirdParty = "thirdParty",
-    
-}
+export const AccountType = {
+    Savings: "saving",
+    Current: "current",
+} as const;
+
+export const CustomerType = {
+    Self: "self",
+    ThirdParty: "thirdParty",
+} as const;


### PR DESCRIPTION
This commit fixes a number of TypeScript errors that were preventing the project from building successfully. Per user request, the fixes are implemented by commenting out unused code rather than deleting it.

The following changes were made:
- Replaced enums with 'as const' objects in 'src/utils/base.enum.ts' to resolve TS1294 errors related to the 'erasableSyntaxOnly' compiler option.
- Commented out unused variables and imports in 'src/pages/account-form/AccountForm.tsx' and 'src/services/account/account.service.ts' to resolve TS6133 errors.